### PR TITLE
Refactor setup-gradle tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,9 @@ jobs:
         distribution: temurin
 
     - name: Build my-gradle-plugins
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        build-root-directory: my-gradle-plugins
-        arguments: build
+      working-directory: my-gradle-plugins
+      run: ./gradlew build
 
     - name: Run my-gradle-project
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        build-root-directory: my-gradle-project
-        arguments: my-settings-task my-project-task
+      working-directory: my-gradle-project
+      run: ./gradlew my-settings-task my-project-task


### PR DESCRIPTION

This job uses deprecated functionality from the gradle/actions/setup-gradle action. Follow the links for upgrade details.
[Using the action to execute Gradle via the `arguments` parameter is deprecated](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated)